### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Testpath is a collection of utilities for Python code working with files and com
 It contains functions to check things on the filesystem, and tools for mocking
 system commands and recording calls to those.
 
-`Documentation on ReadTheDocs <http://testpath.readthedocs.org/en/latest/>`_
+`Documentation on ReadTheDocs <https://testpath.readthedocs.io/en/latest/>`_
 
 e.g.::
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.