### PR TITLE
Use pathlib2 instead of pathlib.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 # command to run tests
 script: py.test
 
-install: if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]] || [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install pathlib; fi
+install: if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]] || [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install pathlib2; fi
 
 # Enable new Travis stack, should speed up builds
 sudo: false

--- a/testpath/asserts.py
+++ b/testpath/asserts.py
@@ -4,9 +4,14 @@ import stat
 try:
     from pathlib import Path
 except ImportError:
-    class Path(object):
-        """Dummy for isinstance checks"""
-        pass
+    try:
+        # Python 2 backport
+        from pathlib2 import Path
+    except ImportError:
+        class Path(object):
+            """Dummy for isinstance checks"""
+            pass
+
 
 __all__ = ['assert_path_exists', 'assert_not_path_exists',
            'assert_isfile', 'assert_not_isfile',

--- a/tests/test_asserts.py
+++ b/tests/test_asserts.py
@@ -1,6 +1,11 @@
 import os
-import pathlib
 import unittest
+
+try:
+    import pathlib
+except ImportError:
+    # Python 2 backport
+    import pathlib2 as pathlib
 
 from testpath.asserts import *
 from testpath.tempdir import TemporaryDirectory


### PR DESCRIPTION
The latter is no longer maintained. Also, `ipython` already uses `pathlib2`, so it's one less dependency for the whole stack.