### PR TITLE
Update Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
 
 # command to run tests
 script: py.test
 
-install: if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]] || [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install pathlib2; fi
+install: if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install pathlib2; fi
 
 # Enable new Travis stack, should speed up builds
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.7"
   - "3.4"
+  - "3.5"
+  - "3.6"
 
 # command to run tests
 script: py.test

--- a/flit.ini
+++ b/flit.ini
@@ -10,9 +10,5 @@ classifiers = Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Topic :: Software Development :: Testing

--- a/flit.ini
+++ b/flit.ini
@@ -4,7 +4,7 @@ author=Jupyter Development Team
 author-email=jupyter@googlegroups.com
 home-page=https://github.com/jupyter/testpath
 description-file=README.rst
-dev-requires = pathlib2; python_version == "2.7" or python_version == "3.3"
+dev-requires = pathlib2; python_version == "2.7"
 classifiers = Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Programming Language :: Python

--- a/flit.ini
+++ b/flit.ini
@@ -5,9 +5,14 @@ author-email=jupyter@googlegroups.com
 home-page=https://github.com/jupyter/testpath
 description-file=README.rst
 dev-requires = pathlib2; python_version == "2.7"
+python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 classifiers = Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
     Topic :: Software Development :: Testing

--- a/flit.ini
+++ b/flit.ini
@@ -5,7 +5,6 @@ author-email=jupyter@googlegroups.com
 home-page=https://github.com/jupyter/testpath
 description-file=README.rst
 dev-requires = pathlib2; python_version == "2.7"
-python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 classifiers = Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Programming Language :: Python


### PR DESCRIPTION
* Add support for Python 3.5-3.6
* Drop support for EOL Python 3.3

https://en.wikipedia.org/wiki/CPython#Version_history

And here's the pip installs for Testpath from PyPI for May 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  45.30% |        121,979 |
| 3.6            |  28.10% |         75,668 |
| 3.4            |  16.01% |         43,112 |
| 3.5            |  10.16% |         27,365 |
| 3.7            |   0.39% |          1,044 |
| 3.3            |   0.05% |            122 |
| 3.8            |   0.00% |              1 |
| Total          |         |        269,291 |

Source: `pypinfo --start-date 2018-05-01 --end-date 2018-05-31 --percent --markdown testpath pyversion`