### PR TITLE
Separate command directory for each MockCommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 /MANIFEST
 /build/
 /dist/
+.pytest_cache/

--- a/testpath/commands.py
+++ b/testpath/commands.py
@@ -9,7 +9,6 @@ __all__ = ['MockCommand', 'assert_calls']
 
 pkgdir = os.path.dirname(__file__)
 
-commands_dir = None
 recording_dir = None
 
 def prepend_to_path(dir):
@@ -57,33 +56,27 @@ class MockCommand(object):
             recording_dir = tempfile.mkdtemp()
         fd, self.recording_file = tempfile.mkstemp(dir=recording_dir,
                                                 prefix=name, suffix='.json')
+        self.command_dir = tempfile.mkdtemp()
         os.close(fd)
 
     def _copy_exe(self):
         bitness = '32' if (sys.maxsize > 2**32) else '64'
         src = os.path.join(pkgdir, 'cli-%s.exe' % bitness)
-        dst = os.path.join(commands_dir, self.name+'.exe')
+        dst = os.path.join(self.command_dir, self.name+'.exe')
         shutil.copy(src, dst)
 
     @property
     def _cmd_path(self):
         # Can only be used once commands_dir has been set
-        p = os.path.join(commands_dir, self.name)
+        p = os.path.join(self.command_dir, self.name)
         if os.name == 'nt':
             p += '-script.py'
         return p
 
     def __enter__(self):
-        global commands_dir
-        if commands_dir is None:
-            commands_dir = tempfile.mkdtemp()
-
         if os.path.isfile(self._cmd_path):
             raise EnvironmentError("Command %r already exists at %s" %
                                             (self.name, self._cmd_path))
-        
-        if commands_dir not in os.environ['PATH'].split(os.pathsep):
-            prepend_to_path(commands_dir)
         
         if self.content is None:
             self.content = _record_run.format(python=sys.executable,
@@ -96,15 +89,14 @@ class MockCommand(object):
             self._copy_exe()
         else:
             os.chmod(self._cmd_path, 0o755) # Set executable bit
-        
+
+        prepend_to_path(self.command_dir)
+
         return self
     
     def __exit__(self, etype, evalue, tb):
-        os.remove(self._cmd_path)
-        if os.name == 'nt':
-            os.remove(os.path.join(commands_dir, self.name+'.exe'))
-        if not os.listdir(commands_dir):
-            remove_from_path(commands_dir)
+        remove_from_path(self.command_dir)
+        shutil.rmtree(self.command_dir)
 
     def get_calls(self):
         """Get a list of calls made to this mocked command.

--- a/testpath/commands.py
+++ b/testpath/commands.py
@@ -60,7 +60,7 @@ class MockCommand(object):
         self.command_dir = tempfile.mkdtemp()
 
     def _copy_exe(self):
-        bitness = '32' if (sys.maxsize > 2**32) else '64'
+        bitness = '64' if (sys.maxsize > 2**32) else '32'
         src = os.path.join(pkgdir, 'cli-%s.exe' % bitness)
         dst = os.path.join(self.command_dir, self.name+'.exe')
         shutil.copy(src, dst)

--- a/testpath/commands.py
+++ b/testpath/commands.py
@@ -56,8 +56,8 @@ class MockCommand(object):
             recording_dir = tempfile.mkdtemp()
         fd, self.recording_file = tempfile.mkstemp(dir=recording_dir,
                                                 prefix=name, suffix='.json')
-        self.command_dir = tempfile.mkdtemp()
         os.close(fd)
+        self.command_dir = tempfile.mkdtemp()
 
     def _copy_exe(self):
         bitness = '32' if (sys.maxsize > 2**32) else '64'


### PR DESCRIPTION
I've been seeing intermittent but regular errors testing Flit on Windows triggered by repeatedly mocking the same command - traceback below.

I haven't been able to work out exactly what causes this problem, but it seems very likely that it's due to removing and recreating a file at the same path; perhaps it is not getting removed correctly. I think that having each mock command add its own directory to PATH and remove it when done should avoid this.

I've also made it so that modifying PATH is the last step when entering the context manager, and the first step when leaving it. This should reduce the chances that a problem with the context manager means it fails to clean up global state.

-----

```
            with MockCommand('git', LIST_FILES_TEMPLATE.format(
>                   python=sys.executable, module='no_docstring.py')):
tests\test_build.py:49: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
C:\Python36\lib\site-packages\testpath\commands.py:96: in __enter__
    self._copy_exe()
C:\Python36\lib\site-packages\testpath\commands.py:66: in _copy_exe
    shutil.copy(src, dst)
C:\Python36\lib\shutil.py:241: in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src = 'C:\\Python36\\lib\\site-packages\\testpath\\cli-64.exe'
dst = 'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\tmp16oq_knr\\git.exe'
    def copyfile(src, dst, *, follow_symlinks=True):
        """Copy data from src to dst.
    
        If follow_symlinks is not set and src is a symbolic link, a new
        symlink will be created instead of copying the file it points to.
    
        """
        if _samefile(src, dst):
            raise SameFileError("{!r} and {!r} are the same file".format(src, dst))
    
        for fn in [src, dst]:
            try:
                st = os.stat(fn)
            except OSError:
                # File most likely does not exist
                pass
            else:
                # XXX What about other special files? (sockets, devices...)
                if stat.S_ISFIFO(st.st_mode):
                    raise SpecialFileError("`%s` is a named pipe" % fn)
    
        if not follow_symlinks and os.path.islink(src):
            os.symlink(os.readlink(src), dst)
        else:
            with open(src, 'rb') as fsrc:
>               with open(dst, 'wb') as fdst:
E               PermissionError: [Errno 13] Permission denied: 'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\tmp16oq_knr\\git.exe'
C:\Python36\lib\shutil.py:121: PermissionError
___________________________ test_get_files_list_git ___________________________
```