### PR TITLE
Remove Python 2 implementation of TemporaryDirectory

### DIFF
--- a/doc/tempdir.rst
+++ b/doc/tempdir.rst
@@ -3,8 +3,8 @@ Utilities for temporary directories
 
 .. module:: testpath.tempdir
 
-This module exposes :func:`tempfile.TemporaryDirectory`, with a backported copy
-so that it can be used on Python 2. In addition, it contains:
+The :mod:`testpath.tempdir` module contains a couple of utilities for working
+with temporary directories:
 
 .. autoclass:: NamedFileInTemporaryDirectory
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dynamic = ["version", "description"]
 
 [project.optional-dependencies]
-test = ["pytest", "pathlib2; python_version == \"2.7\""]
+test = ["pytest"]
 
 [project.urls]
 Documentation = "https://testpath.readthedocs.io/en/latest/"

--- a/testpath/tempdir.py
+++ b/testpath/tempdir.py
@@ -1,4 +1,4 @@
-"""TemporaryDirectory class, copied from Python 3
+"""Extra utilities for temporary directories.
 
 NamedFileInTemporaryDirectory and TemporaryWorkingDirectory from IPython, which
 uses the 3-clause BSD license.
@@ -6,94 +6,7 @@ uses the 3-clause BSD license.
 from __future__ import print_function
 
 import os as _os
-import warnings as _warnings
-import sys as _sys
-
-# This code should only be used in Python versions < 3.2, since after that we
-# can rely on the stdlib itself.
-try:
-    from tempfile import TemporaryDirectory
-
-except ImportError:
-    from tempfile import mkdtemp, template
-
-    class TemporaryDirectory(object):
-        """Create and return a temporary directory.  This has the same
-        behavior as mkdtemp but can be used as a context manager.  For
-        example:
-
-            with TemporaryDirectory() as tmpdir:
-                ...
-
-        Upon exiting the context, the directory and everything contained
-        in it are removed.
-        """
-
-        def __init__(self, suffix="", prefix=template, dir=None):
-            self.name = mkdtemp(suffix, prefix, dir)
-            self._closed = False
-
-        def __enter__(self):
-            return self.name
-
-        def cleanup(self, _warn=False):
-            if self.name and not self._closed:
-                try:
-                    self._rmtree(self.name)
-                except (TypeError, AttributeError) as ex:
-                    # Issue #10188: Emit a warning on stderr
-                    # if the directory could not be cleaned
-                    # up due to missing globals
-                    if "None" not in str(ex):
-                        raise
-                    print("ERROR: {!r} while cleaning up {!r}".format(ex, self,),
-                          file=_sys.stderr)
-                    return
-                self._closed = True
-                if _warn:
-                    self._warn("Implicitly cleaning up {!r}".format(self),
-                               Warning)
-
-        def __exit__(self, exc, value, tb):
-            self.cleanup()
-
-        def __del__(self):
-            # Issue a ResourceWarning if implicit cleanup needed
-            self.cleanup(_warn=True)
-
-
-        # XXX (ncoghlan): The following code attempts to make
-        # this class tolerant of the module nulling out process
-        # that happens during CPython interpreter shutdown
-        # Alas, it doesn't actually manage it. See issue #10188
-        _listdir = staticmethod(_os.listdir)
-        _path_join = staticmethod(_os.path.join)
-        _isdir = staticmethod(_os.path.isdir)
-        _remove = staticmethod(_os.remove)
-        _rmdir = staticmethod(_os.rmdir)
-        _os_error = _os.error
-        _warn = _warnings.warn
-
-        def _rmtree(self, path):
-            # Essentially a stripped down version of shutil.rmtree.  We can't
-            # use globals because they may be None'ed out at shutdown.
-            for name in self._listdir(path):
-                fullname = self._path_join(path, name)
-                try:
-                    isdir = self._isdir(fullname)
-                except self._os_error:
-                    isdir = False
-                if isdir:
-                    self._rmtree(fullname)
-                else:
-                    try:
-                        self._remove(fullname)
-                    except self._os_error:
-                        pass
-            try:
-                self._rmdir(path)
-            except self._os_error:
-                pass
+from tempfile import TemporaryDirectory
 
 
 class NamedFileInTemporaryDirectory(object):


### PR DESCRIPTION
I dropped Python 2 support in #22, so this code is no longer needed.