### PR TITLE
Bump allowed flit_core up to <4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2.0,<3.3"]
+requires = ["flit_core >=3.2.0,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]


### PR DESCRIPTION
The `[project]` table was experimental in Flit 3.2, so the limit was set to `<3.3` in case anything changed. It didn't, so we can just expand it to `<4`.

Closes #25.